### PR TITLE
feat: add orin performance and hardware config

### DIFF
--- a/docker/setup_host/README.md
+++ b/docker/setup_host/README.md
@@ -12,3 +12,22 @@ Please use the following command to check the device (_e.g. video0_) attributes:
 
 `udevadm info --attribute-walk --name /dev/video0`
 
+---
+
+## Run `config_system.sh`
+
+#### **Standard Installation (with GUI)**:
+
+This command executes all configurations but skips the step of disabling the graphical user interface (GUI). It is suitable for your development machine or for vehicles that require local debugging with a display.
+
+```bash
+sudo ./config_system.sh
+```
+
+#### **Headless Mode Installation (GUI disabled)**:
+
+This command executes all configurations and sets the system to boot into command-line mode. This frees up maximum system resources for your autonomous driving application and is suitable for final deployment on in-vehicle computing units.
+
+```bash
+sudo SETUP_HEADLESS_MODE=yes ./config_system.sh
+```

--- a/docker/setup_host/etc/security/limits.d/99-wheelos-core.conf
+++ b/docker/setup_host/etc/security/limits.d/99-wheelos-core.conf
@@ -1,0 +1,3 @@
+# Allow all users to generate unlimited size core dump files for debugging
+*   soft   core   unlimited
+*   hard   core   unlimited

--- a/docker/setup_host/etc/systemd/network/10-can0.network
+++ b/docker/setup_host/etc/systemd/network/10-can0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=can0
+
+[CAN]
+BitRate=500000

--- a/docker/setup_host/etc/systemd/network/10-can1.network
+++ b/docker/setup_host/etc/systemd/network/10-can1.network
@@ -1,0 +1,5 @@
+[Match]
+Name=can1
+
+[CAN]
+BitRate=500000

--- a/docker/setup_host/etc/systemd/system/jetson-performance.service
+++ b/docker/setup_host/etc/systemd/system/jetson-performance.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Set Jetson Performance Mode (MAXN) and Clocks
+
+[Service]
+Type=oneshot
+ExecStartPre=nvpmodel -m 0
+ExecStart=jetson_clocks
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
add orin performance and hardware config

## test on jeston nx

```
nvidia@tegra-ubuntu:~/Desktop/apollo-lite$ sudo bash docker/setup_host/config_system.sh 
[INFO] No argument provided. Defaulting to 'install' mode.
[INFO] Starting host machine setup process...
[INFO] Checking host setup pre-conditions...
[INFO] APOLLO_ROOT_DIR (/home/nvidia/Desktop/apollo-lite) detected.
[INFO] All required commands are available.
[INFO] Udev rules source directory detected.
[INFO] Autostart service source file detected.
[SUCCESS] All host setup pre-conditions met.
[INFO] Setting up core dump format...
[INFO] Core dump configuration already detected and active. Skipping.
[INFO] Configuring system-wide core dump size limits...
[SUCCESS] Core dump size limits configured.
[INFO] Creating Bazel cache directory...
[INFO] Bazel cache directory '/var/cache/bazel/repo_cache' already exists. Skipping creation.
[SUCCESS] Bazel cache directory configured.
[INFO] Standardizing NTP synchronization on chrony...
[SUCCESS] chrony (chrony.service) is already enabled and running correctly.
[INFO] Verifying chrony synchronization status...
Reference ID    : B97DBE38 (prod-ntp-3.ntp1.ps5.canonical.com)
Stratum         : 3
Ref time (UTC)  : Thu Nov 06 00:49:00 2025
System time     : 0.001472338 seconds slow of NTP time
Last offset     : -0.000436278 seconds
RMS offset      : 0.003407748 seconds
Frequency       : 28.154 ppm slow
Residual freq   : -0.013 ppm
Skew            : 6.699 ppm
Root delay      : 0.242310092 seconds
Root dispersion : 0.002435031 seconds
Update interval : 65.1 seconds
Leap status     : Normal
[INFO] Adding udev rules from '/home/nvidia/Desktop/apollo-lite/docker/setup_host/etc/udev/rules.d' to '/etc/udev/rules.d'...
[INFO] Udev rules already appear to be in place. Skipping copy.
[INFO] Reloading udev rules and triggering devices...
[SUCCESS] Udev rules applied.
[INFO] Adding uvcvideo clock configuration to /etc/modprobe.d/uvcvideo.conf...
[INFO] uvcvideo clock configuration already detected. Skipping write.
[INFO] Reloading uvcvideo module if loaded...
[INFO] uvcvideo module not currently loaded. No unload needed.
[SUCCESS] uvcvideo module configured and reloaded.
[INFO] Configuring CAN bus interfaces using systemd-networkd...
[INFO] CAN network configuration files copied.
[INFO] Enabling and restarting systemd-networkd service...
[SUCCESS] CAN bus interfaces configured via systemd-networkd.
[INFO] Configuring Jetson performance services (nvpmodel and jetson_clocks)...
[SUCCESS] Jetson performance service enabled and started.
[INFO] SETUP_HEADLESS_MODE is not 'yes'. Skipping GUI disable.
[INFO] Ensuring user 'nvidia' is in the Docker group...
[INFO] User 'nvidia' is already in the Docker group. Skipping.
[INFO] Installing and configuring the autostart systemd service...
[INFO] Target user 'nvidia' validated.
[INFO] Apollo root directory '/home/nvidia/Desktop/apollo-lite' validated.
[INFO] Copying '/home/nvidia/Desktop/apollo-lite/docker/setup_host/etc/systemd/system/autostart.service' to '/etc/systemd/system/autostart.service'...
[INFO] Customizing service file with user='nvidia' and path='/home/nvidia/Desktop/apollo-lite'...
[INFO] Reloading systemd daemon...
[INFO] Enabling 'autostart.service' to run on boot...
[SUCCESS] Autostart service installed and enabled successfully.
[INFO] The autonomous driving system will now start automatically on the next boot.
[SUCCESS] Host machine setup completed successfully!
```
