### PR TITLE
chore: improve config_system

### DIFF
--- a/docker/setup_host/config_system.sh
+++ b/docker/setup_host/config_system.sh
@@ -278,15 +278,15 @@ apply_udev_rules() {
   fi
 
   if "${all_udev_rules_present}"; then
-    info "Udev rules already appear to be in place. Skipping copy."
-  else
-    sudo cp -r "${UDEV_RULES_SRC_DIR}"/* "${UDEV_RULES_DEST_DIR}/"
-    if [ $? -ne 0 ]; then
-      error "Failed to copy udev rules. Check source/destination permissions or path."
-      return 1
-    fi
-    info "Udev rules copied."
+    info "Udev rules already appear to be in place. Force copy."
   fi
+
+  sudo cp -r "${UDEV_RULES_SRC_DIR}"/* "${UDEV_RULES_DEST_DIR}/"
+  if [ $? -ne 0 ]; then
+    error "Failed to copy udev rules. Check source/destination permissions or path."
+    return 1
+  fi
+  info "Udev rules copied."
 
   info "Reloading udev rules and triggering devices..."
   sudo udevadm control --reload-rules

--- a/docker/setup_host/etc/udev/rules.d/99-usbtty.rules
+++ b/docker/setup_host/etc/udev/rules.d/99-usbtty.rules
@@ -1,3 +1,3 @@
-SUBSYSTEM=="tty", SUBSYSTEMS=="usb-serial", DRIVERS=="novatel_gps", ATTRS{port_number}=="0", MODE="0666", SYMLINK+="novatel0", OWNER="apollo", GROUP="apollo"
-SUBSYSTEM=="tty", SUBSYSTEMS=="usb-serial", DRIVERS=="novatel_gps", ATTRS{port_number}=="1", MODE="0666", SYMLINK+="novatel1", OWNER="apollo", GROUP="apollo"
-SUBSYSTEM=="tty", SUBSYSTEMS=="usb-serial", DRIVERS=="novatel_gps", ATTRS{port_number}=="2", MODE="0666", SYMLINK+="novatel2", OWNER="apollo", GROUP="apollo"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb-serial", ATTRS{port_number}=="0", MODE="0666", SYMLINK+="novatel0", GROUP="dialout"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb-serial", ATTRS{port_number}=="1", MODE="0666", SYMLINK+="novatel1", GROUP="dialout"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb-serial", ATTRS{port_number}=="2", MODE="0666", SYMLINK+="novatel2", GROUP="dialout"


### PR DESCRIPTION
- Add Udev to force override; otherwise, configuration changes will not take effect.
- Relax the `99-usbtty.rules` rule, otherwise it's prone to mismatches.