### PR TITLE
chore: improve build progress

### DIFF
--- a/scripts/ci/apollo_build.sh
+++ b/scripts/ci/apollo_build.sh
@@ -284,7 +284,8 @@ function run_bazel_build() {
     jobs_args="--jobs=${CUSTOM_JOBS}"
   fi
   # default set cpus number according to the total cpu cores
-  local cpu_count=$(($(nproc) / 2))
+  local nproc_cnt=$(nproc)
+  local cpu_count=$(( nproc_cnt > 8 ? 8 : nproc_cnt ))
   local cpus_args="--local_resources=cpu=${cpu_count}"
   if [[ -n "${CUSTOM_CPUS}" ]]; then
     cpus_args="--local_resources=cpu=${CUSTOM_CPUS}"

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -17,6 +17,7 @@ common --enable_bzlmod
 # Prefer https://bcr.bazel.build/
 build --registry=https://bcr.bazel.build/
 build --registry=https://raw.githubusercontent.com/wheelos/bazel-central-registry/main
+build --registry=file:///apollo/data/bazel-central-registry
 
 # Set up a shared cache to avoid repeated pulls from remote libraries
 build --repository_cache=/var/cache/bazel/repo_cache


### PR DESCRIPTION
- Add a local bzlmod repository.
- The default maximum compilation core is set to 8.