### PR TITLE
feat: improve ptp auto start service

### DIFF
--- a/docker/setup_host/config_system.sh
+++ b/docker/setup_host/config_system.sh
@@ -39,6 +39,23 @@ AUTOSERVICE_DEST_FILE="/etc/systemd/system/autostart.service"
 # User who will run the autonomous driving stack. SUDO_USER is the user who invoked sudo.
 WHL_HOST_USER="${SUDO_USER:-$(whoami)}"
 
+# --- PTP Variables ---
+PTP_CONF_SRC="${APOLLO_ROOT_DIR}/docker/setup_host/etc/linuxptp/ptp4l.conf"
+PTP_CONF_DEST_DIR="/etc/linuxptp"
+PTP_CONF_DEST="/etc/linuxptp/ptp4l.conf"
+
+# Service Base Files
+SYSTEMD_DEST_DIR="/etc/systemd/system"
+PTP4L_SERVICE_SRC="${APOLLO_ROOT_DIR}/docker/setup_host/etc/systemd/system/ptp4l.service"
+PHC2SYS_SERVICE_SRC="${APOLLO_ROOT_DIR}/docker/setup_host/etc/systemd/system/phc2sys.service"
+
+# Service Overrides
+PTP4L_OVERRIDE_SRC="${APOLLO_ROOT_DIR}/docker/setup_host/etc/systemd/system/ptp4l.service.d/override.conf"
+PTP4L_OVERRIDE_DEST_DIR="/etc/systemd/system/ptp4l.service.d"
+
+PHC2SYS_OVERRIDE_SRC="${APOLLO_ROOT_DIR}/docker/setup_host/etc/systemd/system/phc2sys.service.d/override.conf"
+PHC2SYS_OVERRIDE_DEST_DIR="/etc/systemd/system/phc2sys.service.d"
+
 # --- Color Definitions for Output ---
 BOLD='\033[1m'
 RED='\033[0;31m'
@@ -544,6 +561,50 @@ configure_headless_mode() {
     return 0
 }
 
+# Configures Linux PTP (ptp4l and phc2sys) as Master.
+configure_ptp() {
+  info "Configuring Linux PTP as Master..."
+
+  # 1. Install linuxptp
+  if ! command -v ptp4l &> /dev/null; then
+    sudo apt-get update && sudo apt-get install -y linuxptp
+  fi
+
+  # 2. Force overwrite configuration file
+  if [ -f "${PTP_CONF_SRC}" ]; then
+    sudo mkdir -p "${PTP_CONF_DEST_DIR}"
+    sudo cp -f "${PTP_CONF_SRC}" "${PTP_CONF_DEST}"
+    success "PTP configuration file copied."
+  fi
+
+  # 3. Systemd Unit Files
+  [ -f "${PTP4L_SERVICE_SRC}" ] && sudo cp -f "${PTP4L_SERVICE_SRC}" "${SYSTEMD_DEST_DIR}/ptp4l.service"
+  [ -f "${PHC2SYS_SERVICE_SRC}" ] && sudo cp -f "${PHC2SYS_SERVICE_SRC}" "${SYSTEMD_DEST_DIR}/phc2sys.service"
+
+  # 4. Overrides
+  [ -f "${PTP4L_OVERRIDE_SRC}" ] && {
+    sudo mkdir -p "${PTP4L_OVERRIDE_DEST_DIR}";
+    sudo cp -f "${PTP4L_OVERRIDE_SRC}" "${PTP4L_OVERRIDE_DEST_DIR}/override.conf";
+  }
+  [ -f "${PHC2SYS_OVERRIDE_SRC}" ] && {
+    sudo mkdir -p "${PHC2SYS_OVERRIDE_DEST_DIR}";
+    sudo cp -f "${PHC2SYS_OVERRIDE_SRC}" "${PHC2SYS_OVERRIDE_DEST_DIR}/override.conf";
+  }
+
+  # 5. Restart service
+  sudo systemctl daemon-reload
+  sudo systemctl enable ptp4l phc2sys
+  sudo systemctl restart ptp4l phc2sys
+
+  # 6. info
+  if systemctl is-active --quiet ptp4l; then
+    success "PTP E2E is ACTIVE."
+  else
+    error "PTP failed to start. Check 'journalctl -u ptp4l'."
+    return 1
+  fi
+}
+
 
 # --- Main Host Setup Orchestration Function ---
 # This is the primary entry point for setting up the host machine.
@@ -576,6 +637,12 @@ setup_host_machine() {
   # 4. Configure NTP synchronization
   if ! configure_ntp; then
     error "Failed to configure NTP synchronization. Aborting host setup."
+    return 1
+  fi
+
+  # 4.5 Configure Linux PTP (New Step)
+  if ! configure_ptp; then
+    error "Failed to configure Linux PTP. Aborting host setup."
     return 1
   fi
 

--- a/docker/setup_host/etc/linuxptp/ptp4l.conf
+++ b/docker/setup_host/etc/linuxptp/ptp4l.conf
@@ -1,10 +1,43 @@
 [global]
-domainNumber 0
-time_stamping hardware
-logSyncInterval 0
-logMinDelayReqInterval 0
-priority1 128
-priority2 128
-transportSpecific 1
+# --- Role and Priority ---
+# Enables two-step synchronization for higher accuracy
+twoStepFlag             1
+masterOnly              1
+# Lower values indicate higher priority (0-255)
+priority1               10
+priority2               10
+domainNumber            0
 
-[eth1]
+# --- Time Offset (TAI-UTC) ---
+# Explicitly set the offset (currently 37s) for use with phc2sys -w
+utc_offset              37
+
+# --- Message Intervals (Logarithmic scale: 2^n) ---
+# Announce interval: 2^1 = 2 seconds
+logAnnounceInterval     1
+# Sync interval: 2^0 = 1 second
+logSyncInterval         0
+# Minimum Delay Request interval: 2^0 = 1 second
+logMinDelayReqInterval  0
+
+# --- Runtime & Logging ---
+logging_level           6
+verbose                 1
+summary_interval        0
+
+# --- Servo Settings ---
+# Force clock step (jump) if offset exceeds 0.00002s (20us), instead of slow slewing
+step_threshold          0.00002
+clock_servo             pi
+
+# --- Transport & Mechanism ---
+# Standard UDP/IPv4 transport for L3 compatibility
+network_transport       UDPv4
+# End-to-End delay measurement mechanism
+delay_mechanism         E2E
+# Enables Hardware Timestamping for microsecond precision
+time_stamping           hardware
+transportSpecific       0x0
+
+# --- Interface Definition ---
+[eth0]

--- a/docker/setup_host/etc/systemd/system/phc2sys.service
+++ b/docker/setup_host/etc/systemd/system/phc2sys.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Synchronize PHC to system clock
+After=ptp4l.service
+Requires=ptp4l.service
+
+[Service]
+Type=simple
+# -a indicates automatic interface selection, and -r indicates synchronizing
+# the PHC to the system clock.
+ExecStart=/usr/sbin/phc2sys -a -r
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/setup_host/etc/systemd/system/phc2sys.service.d/override.conf
+++ b/docker/setup_host/etc/systemd/system/phc2sys.service.d/override.conf
@@ -1,13 +1,12 @@
 [Unit]
-Description=Synchronize PTP hardware clock (PHC) to system clock
+Description=Synchronize system clock to PTP hardware clock (PHC)
 After=ptp4l.service
 Requires=ptp4l.service
 
 [Service]
 Type=simple
 ExecStart=
-ExecStart=/usr/sbin/phc2sys -c /dev/ptp0 -s CLOCK_REALTIME -w -m
-Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target
+# -s System clock, -c Network card hardware clock, -w Wait for ptp4l to be ready, -m Output log
+ExecStart=/usr/sbin/phc2sys -s CLOCK_REALTIME -c eth0 -w -m
+Restart=always
+RestartSec=5

--- a/docker/setup_host/etc/systemd/system/ptp4l.service
+++ b/docker/setup_host/etc/systemd/system/ptp4l.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Precision Time Protocol (PTP) service
+After=network.target
+
+[Service]
+Type=simple
+# -f specifies the configuration file path, -i specifies the network interface
+# card.
+ExecStart=/usr/sbin/ptp4l -f /etc/linuxptp/ptp4l.conf
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/setup_host/etc/systemd/system/ptp4l.service.d/override.conf
+++ b/docker/setup_host/etc/systemd/system/ptp4l.service.d/override.conf
@@ -1,3 +1,8 @@
+[Unit]
+After=network-online.target
+Wants=network-online.target
+
 [Service]
 ExecStart=
-ExecStart=/usr/sbin/ptp4l -f /etc/linuxptp/ptp4l.conf -i eth1
+# Add -m to ensure log output is to the systemd journal
+ExecStart=/usr/sbin/ptp4l -f /etc/linuxptp/ptp4l.conf -i eth0 -m

--- a/docker/setup_host/ptp_diagnostic.sh
+++ b/docker/setup_host/ptp_diagnostic.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# ==============================================================================
+# Apollo-Lite PTP Sync Diagnostic Tool
+# Purpose: Deep analysis of PTP Master health and synchronization chain.
+# Usage: sudo ./ptp_diagnostic.sh [interface]
+# ==============================================================================
+
+IFACE=${1:-"eth0"}
+BOLD='\033[1m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[34m'
+NC='\033[0m'
+
+echo -e "${BOLD}${BLUE}=== Apollo-Lite PTP Health Dashboard ===${NC}"
+
+# --- Step 1: Network Interface & Link Status ---
+echo -e "\n${BOLD}>>> Step 1: Interface & Link Status [ $IFACE ]${NC}"
+if ! ip link show "$IFACE" > /dev/null 2>&1; then
+    echo -e "[${RED}FAIL${NC}] Interface $IFACE does not exist."
+    exit 1
+fi
+
+LINK_STATE=$(cat /sys/class/net/"$IFACE"/operstate)
+if [[ "$LINK_STATE" == "up" ]]; then
+    echo -e "[${GREEN}OK${NC}] Interface link is UP."
+else
+    echo -e "[${RED}ERROR${NC}] Link is $LINK_STATE. Please check cable/connection."
+fi
+
+# --- Step 2: Hardware Timestamping Capability ---
+echo -e "\n${BOLD}>>> Step 2: PHC Hardware Capability${NC}"
+ETHTOOL_OUT=$(ethtool -T "$IFACE" 2>&1)
+if [[ $ETHTOOL_OUT == *"SOF_TIMESTAMPING_TX_HARDWARE"* ]]; then
+    echo -e "[${GREEN}OK${NC}] Hardware Timestamping supported."
+    PTP_DEV=$(echo "$ETHTOOL_OUT" | grep "PTP Hardware Clock" | awk '{print $NF}')
+    echo -e "[${BLUE}INFO${NC}] Using PTP Device: /dev/ptp$PTP_DEV"
+else
+    echo -e "[${RED}ERROR${NC}] $IFACE lacks Hardware Timestamping. PTP precision will be poor (Software only)."
+fi
+
+# --- Step 3: Upstream Time Source (Chrony) ---
+echo -e "\n${BOLD}>>> Step 3: Upstream Sync (Master Source)${NC}"
+if command -v chronyc &> /dev/null; then
+    CHRONY_STATE=$(chronyc tracking)
+    if echo "$CHRONY_STATE" | grep -q "Reference ID"; then
+        STRATUM=$(echo "$CHRONY_STATE" | grep "Stratum" | awk '{print $3}')
+        echo -e "[${GREEN}OK${NC}] Chrony is synced (Stratum: $STRATUM)."
+    else
+        echo -e "[${YELLOW}WARNING${NC}] Chrony is active but NOT synced to external NTP. PTP time may drift."
+    fi
+else
+    echo -e "[${RED}ERROR${NC}] Chrony not found. System clock reference is unreliable."
+fi
+
+# --- Step 4: Service Health & Process Check ---
+echo -e "\n${BOLD}>>> Step 4: Systemd Service Status${NC}"
+for SERVICE in ptp4l phc2sys; do
+    if systemctl is-active --quiet "$SERVICE"; then
+        CONF_FILE=$(ps aux | grep "$SERVICE" | grep -v grep | sed 's/.*-f //;s/ .*//')
+        echo -e "[${GREEN}OK${NC}] $SERVICE is running. (Config: ${CONF_FILE:-"Default CLI"})"
+    else
+        echo -e "[${RED}FAIL${NC}] $SERVICE is NOT running!"
+        echo -e "${YELLOW}Hint: Run 'journalctl -u $SERVICE -e' for logs.${NC}"
+    fi
+done
+
+# --- Step 5: Real-time Sync Analysis ---
+echo -e "\n${BOLD}>>> Step 5: Synchronization Precision Analysis${NC}"
+PHC_LOG=$(journalctl -u phc2sys -n 20 --no-pager)
+
+if [[ $PHC_LOG == *"s2"* ]]; then
+    LAST_LINE=$(echo "$PHC_LOG" | grep "offset" | tail -n 1)
+    OFFSET=$(echo "$LAST_LINE" | grep -oP 'offset\s+\K[-0-9]+')
+    FREQ=$(echo "$LAST_LINE" | grep -oP 'freq\s+\K[-0-9]+')
+
+    : ${OFFSET:=99999}
+
+    echo -e "[${GREEN}LOCKED${NC}] phc2sys status: s2 (Phase Locked)."
+    echo -e "  - Current Offset: ${BOLD}${OFFSET}${NC} ns"
+    echo -e "  - Freq Adjust  : ${FREQ} ppb"
+
+    if [ ${OFFSET#-} -lt 500 ]; then
+        echo -e "${GREEN}>>> SYSTEM HEALTHY: High-precision sync established. <<<${NC}"
+    else
+        echo -e "${YELLOW}>>> WARNING: Offset > 500ns. Check system load or interrupt binding. <<<${NC}"
+    fi
+else
+    echo -e "[${RED}SYNCING${NC}] phc2sys has not reached 's2' state yet."
+    echo -e "${YELLOW}Action: Check if ptp4l has found any Slaves or if domainNumber matches.${NC}"
+fi
+
+echo -e "\n${BLUE}=========================================${NC}"


### PR DESCRIPTION
First, you need to modify the network interface settings in the following files:
```
docker/setup_host/etc/linuxptp/ptp4l.conf
docker/setup_host/etc/systemd/system/phc2sys.service.d/override.conf
docker/setup_host/etc/systemd/system/ptp4l.service.d/override.conf
```

Then run `docker/setup_host/ptp_diagnostic.sh` to check if it executed successfully.