### PR TITLE
Refactor whl-can to make the buttons more concise.

### DIFF
--- a/modules/tools/whl-can/whl_can.py
+++ b/modules/tools/whl-can/whl_can.py
@@ -399,7 +399,6 @@ class KeyboardController:
             )
             scr.addstr(4, c1, f"EPB:     [{'ON' if self.epb else ' '}]")
             scr.addstr(5, c1, f"SIGNAL:  {self._signal_text()}")
-            scr.addstr(6, c1, f"THRESH:  {self.turn_signal_threshold:.1f}")
 
             c2 = 20
             bar_speed = self._draw_bar(abs(self.speed), SPEED_MAX, 12)
@@ -421,7 +420,8 @@ class KeyboardController:
                     / (STEERING_MAX - STEERING_MIN)
                 )
             )
-            idx = max(0, min(steer_steps, idx))
+            # reverse to match intuitive display, `+` for left, `-` for right
+            idx = max(0, min(steer_steps, steer_steps - idx))
             s_list = list(steer_visual)
             if 0 <= idx < len(s_list):
                 s_list[idx] = "O"
@@ -430,7 +430,7 @@ class KeyboardController:
             scr.addstr(
                 5,
                 c3,
-                f"HIGH:{'ON' if self.high_beam else 'OFF'} EMG:{'ON' if self.emergency_light else 'OFF'}",
+                f"HIGH:{'ON' if self.high_beam else 'OFF'}",
             )
 
             scr.addstr(11, 0, "-" * w)
@@ -449,7 +449,7 @@ class KeyboardController:
                     12, 2, "W/S: Drive | A/D: Steer | B/N: Brake +/- | Space: E-Stop"
                 )
                 scr.addstr(13, 2, "G: Gear | P: EPB | 1/2/3: Mode | Enter: Auto-Drive")
-                scr.addstr(14, 2, "q/e/m: Left/Right/Hazard (toggle) | c: Cancel | o: Horn")
+                scr.addstr(14, 2, "q/e/m: Left/Right/Hazard (toggle) | o: Horn")
                 scr.addstr(15, 2, "l: Lights (Off/Low/High)")
 
             scr.refresh()


### PR DESCRIPTION


## Control Key Mapping

| Category | Key(s) | Function Description | Optimization Rationale |
|--------|--------|----------------------|------------------------|
| Driving | W / S | Increase / Decrease target (speed / throttle / accel, depends on mode) | Matches common WASD forward/backward driving intuition |
| Steering | A / D | Turn left / right (adjust `steering`) | Classic lateral control using A/D |
| Braking | B / N | Brake force (+ / -) | Semantic: B increases, N decreases brake force (case-insensitive) |
| Emergency | Space | Emergency braking (sets brake to max) | Most accessible key in emergencies; fastest reaction |
| Transmission | G | Cycle gears (P → R → N → D) | Single-key cycle for quick gear change |
| Parking | P | Electronic Parking Brake (EPB toggle) | Clear Parking semantics |
| Turn Signals | Q / E / M | Toggle Left / Right / Hazard turn signals | Toggle behavior: press to enable, press again to cancel |
| Cancel Lights | (none mapped) | — | Note: UI help mentions `c: Cancel` but `c` is not mapped in the code |
| Warning / Hazard | M | Hazard lights (same as above) | Easy index-finger access; mapped to `m` as toggle |
| Lighting | L | Cycle headlights (Off → Low → High) | Lights semantic mapping; cyclic control |
| Horn | O | Horn (toggle) | Placed away from main controls to reduce accidental activation |
| System — Engage | Enter | Toggle autonomous driving engage / takeover | Enter implies confirm/engage |
| System — Quit | Esc | Quit program | Standard escape-to-exit mapping |
| System — Help | H | Toggle help menu | Quick access to help |
| Control Mode | 1 / 2 / 3 | Set control mode to SPEED / THROTTLE / ACCEL respectively | Direct numeric mode selection for testing and control |
| EPB / Status | (display-only) | Status shown in UI (`EPB`, `GEAR`, `SIGNAL`, etc.) | Read-only indicators in UI |
