### PR TITLE
166 feature independent dreamview frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ docs/demo_guide/*.record
 
 # Directory for binary distribution
 output
+modules/dreamview/frontend
 
 # Flamegraph files
 tools/FlameGraph


### PR DESCRIPTION
 Independent dreamview frontend
- depends dreamview frontend installation package in bazel
- Delete dreamview frontend and move it to a separate repository. https://github.com/wheelos/frontend