### PR TITLE
chore: improve docker start scripts

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -56,21 +56,20 @@ if [[ -d "${RCFILES_DIR}" ]]; then
     fi
   done
 fi
-# Set user files ownership to current user, such as .bashrc, .profile, etc.
-chown -R "${USER_ID}:${GROUP_ID}" ${USER_HOME}/.*
+
+find "${USER_HOME}" -maxdepth 1 -name ".*" ! -name "." ! -name " .. " -exec chown -R "${USER_ID}:${GROUP_ID}" {} +
+chown "${USER_ID}:${GROUP_ID}" "${USER_HOME}"
+
 if [ -f "/apollo/cyber/setup.bash" ]; then
     source /apollo/cyber/setup.bash
 fi
 
 # 4. Business logic branch
-# If AUTO_BOOTSTRAP=true is set (usually for one-click startup in Dev mode)
 if [[ "${AUTO_BOOTSTRAP}" == "true" ]]; then
     echo "[Entrypoint] Auto-starting Dreamview..."
-    # run as user
-    # sudo -u ${USER_NAME} bash -c "cd /apollo && source ~/.bashrc && source ~/.bash_aliases && source /apollo/cyber/setup.bash && ./scripts/bootstrap.sh start > /apollo/data/log/bootstrap.log 2>&1"
     runuser -u ${USER_NAME} -- bash -l -c "cd /apollo && ./scripts/bootstrap.sh start > /apollo/data/log/bootstrap.log 2>&1" || true
 fi
 
 # 5. Keep running the container
 echo ">>> Container is ready for user: $USER_NAME"
-exec tail -f /dev/null
+exec "$@"

--- a/docker/services/docker-compose.yml
+++ b/docker/services/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     restart: "no"
     tty: true
     stdin_open: true
+    init: true
 
-    # need root user to run entrypoint.sh to add user and group, and change ownership of files
     user: "root"
     working_dir: /apollo
     shm_size: ${SHM_SIZE}
@@ -32,3 +32,5 @@ services:
       - ${BAZEL_CACHE_DIR}:${BAZEL_CACHE_DIR}
 
     entrypoint: ["/bin/bash", "/entrypoint.sh"]
+
+    command: ["runuser", "-u", "${USER_NAME}", "--", "/bin/bash", "-l"]


### PR DESCRIPTION
improve entrypoint handling and fix zombie process leakage

- Enable `init: true` (tini) to properly reap zombie/defunct processes.
- Replace `tail -f /dev/null` anti-pattern with `exec "$@"` to pass control to user-land bash.
- Fix dotfile `chown` safety bug in entrypoint script to prevent runtime crash.
- Clean up nested shell commands and ensure correct log directory permissions.