### PR TITLE
fix: add memlock to all docker

### DIFF
--- a/docker/services/docker-compose.test.yml
+++ b/docker/services/docker-compose.test.yml
@@ -6,17 +6,6 @@ services:
       - 8.8.8.8
       - 1.1.1.1
 
-    security_opt:
-      - seccomp:unconfined
-
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-
-    cap_add:
-      - SYS_NICE
-
     environment:
       - USE_GPU_HOST=${USE_GPU_HOST}
       - TEST_MODE=true

--- a/docker/services/docker-compose.yml
+++ b/docker/services/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     user: "root"
     working_dir: /apollo
     shm_size: ${SHM_SIZE}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     env_file:
       - ${RUNTIME_ENV_FILE}
 


### PR DESCRIPTION
io_uring requires the kernel capability to lock memory (via RLIMIT_MEMLOCK) during queue initialization (io_uring_setup) and buffer registration (IORING_REGISTER_BUFFERS).

Without sufficient memlock resource limits, applications using io_uring fail with EPERM (Operation not permitted) or ENOMEM (Out of memory) errors inside Docker containers.

This PR sets memlock: -1 (unlimited) across all Docker configurations to grant the required memory locking permissions, enabling proper operation of io_uring-based services.